### PR TITLE
[SWM-63]: 스터디 목록 조회 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ application-dev.yml
 application-local.yml
 application-prod.yml
 application-test.yml
+src/main/generated
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/jj/swm/domain/study/controller/StudyQueryController.java
+++ b/src/main/java/com/jj/swm/domain/study/controller/StudyQueryController.java
@@ -7,7 +7,9 @@ import com.jj.swm.global.common.dto.ApiResponse;
 import com.jj.swm.global.common.dto.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 import java.util.UUID;
@@ -22,15 +24,14 @@ public class StudyQueryController {
     @GetMapping("/v1/study")
     public ApiResponse<PageResponse<StudyInquiryResponse>> getStudyList(
             Principal principal,
-            @RequestParam(value = "page", defaultValue = "0") int pageNo,
             @Value("${study.page.size}") int pageSize,
-            StudyInquiryCondition inquiryConditionRequest
+            StudyInquiryCondition inquiryCondition
     ) {
         PageResponse<StudyInquiryResponse> pageResponse = studyQueryService.getList(
-                principal != null ? UUID.fromString(principal.getName()) : null,
-                pageNo,
+                UUID.fromString("d554b429-366f-4d8e-929d-bb5479623eb9"),
+                //                principal != null ? UUID.fromString(principal.getName()) : null,
                 pageSize,
-                inquiryConditionRequest
+                inquiryCondition
         );
 
         return ApiResponse.ok(pageResponse);

--- a/src/main/java/com/jj/swm/domain/study/controller/StudyQueryController.java
+++ b/src/main/java/com/jj/swm/domain/study/controller/StudyQueryController.java
@@ -1,0 +1,38 @@
+package com.jj.swm.domain.study.controller;
+
+import com.jj.swm.domain.study.dto.StudyInquiryCondition;
+import com.jj.swm.domain.study.dto.response.StudyInquiryResponse;
+import com.jj.swm.domain.study.service.StudyQueryService;
+import com.jj.swm.global.common.dto.ApiResponse;
+import com.jj.swm.global.common.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class StudyQueryController {
+
+    private final StudyQueryService studyQueryService;
+
+    @GetMapping("/v1/study")
+    public ApiResponse<PageResponse<StudyInquiryResponse>> getStudyList(
+            Principal principal,
+            @RequestParam(value = "page", defaultValue = "0") int pageNo,
+            @Value("${study.page.size}") int pageSize,
+            StudyInquiryCondition inquiryConditionRequest
+    ) {
+        PageResponse<StudyInquiryResponse> pageResponse = studyQueryService.getList(
+                principal != null ? UUID.fromString(principal.getName()) : null,
+                pageNo,
+                pageSize,
+                inquiryConditionRequest
+        );
+
+        return ApiResponse.ok(pageResponse);
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/dto/StudyBookmarkInfo.java
+++ b/src/main/java/com/jj/swm/domain/study/dto/StudyBookmarkInfo.java
@@ -1,0 +1,18 @@
+package com.jj.swm.domain.study.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class StudyBookmarkInfo {
+
+    private final Long id;
+
+    private final Long studyId;
+
+    @QueryProjection
+    public StudyBookmarkInfo(Long id, Long studyId) {
+        this.id = id;
+        this.studyId = studyId;
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/dto/StudyInquiryCondition.java
+++ b/src/main/java/com/jj/swm/domain/study/dto/StudyInquiryCondition.java
@@ -13,5 +13,9 @@ public class StudyInquiryCondition {
 
     private StudyStatus status;
 
+    private Long lastStudyId;
+
     private SortCriteria sortCriteria;
+
+    private Integer lastSortValue;
 }

--- a/src/main/java/com/jj/swm/domain/study/dto/StudyInquiryCondition.java
+++ b/src/main/java/com/jj/swm/domain/study/dto/StudyInquiryCondition.java
@@ -1,0 +1,17 @@
+package com.jj.swm.domain.study.dto;
+
+import com.jj.swm.domain.study.entity.StudyCategory;
+import com.jj.swm.domain.study.entity.StudyStatus;
+import com.jj.swm.domain.study.enums.SortCriteria;
+import lombok.*;
+
+@Getter
+@Setter
+public class StudyInquiryCondition {
+
+    private StudyCategory category;
+
+    private StudyStatus status;
+
+    private SortCriteria sortCriteria;
+}

--- a/src/main/java/com/jj/swm/domain/study/dto/response/StudyInquiryResponse.java
+++ b/src/main/java/com/jj/swm/domain/study/dto/response/StudyInquiryResponse.java
@@ -1,0 +1,60 @@
+package com.jj.swm.domain.study.dto.response;
+
+import com.jj.swm.domain.study.entity.Study;
+import com.jj.swm.domain.study.entity.StudyCategory;
+import com.jj.swm.domain.study.entity.StudyStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StudyInquiryResponse {
+
+    private Long studyId;
+
+    private String title;
+
+    private String content;
+
+    private StudyCategory category;
+
+    private String thumbnail;
+
+    private int likeCount;
+
+    private int commentCount;
+
+    private StudyStatus status;
+
+    private int viewCount;
+
+    private String nickname;
+
+    private String profileImageUrl;
+
+    private Long studyBookmarkId;
+
+    private List<StudyTagInquiryResponse> tagInquiryListResponse;
+
+    public static StudyInquiryResponse of(Study study, Long studyBookmarkId) {
+        return StudyInquiryResponse.builder()
+                .studyId(study.getId())
+                .title(study.getTitle())
+                .content(study.getContent())
+                .category(study.getCategory())
+                .thumbnail(study.getThumbnail())
+                .likeCount(study.getLikeCount())
+                .commentCount(study.getCommentCount())
+                .status(study.getStatus())
+                .viewCount(study.getViewCount())
+                .nickname(study.getUser().getNickname())
+                .profileImageUrl(study.getUser().getProfileImageUrl())
+                .studyBookmarkId(studyBookmarkId)
+                .tagInquiryListResponse(study.getStudyTags().stream()
+                        .map(StudyTagInquiryResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/dto/response/StudyTagInquiryResponse.java
+++ b/src/main/java/com/jj/swm/domain/study/dto/response/StudyTagInquiryResponse.java
@@ -1,0 +1,21 @@
+package com.jj.swm.domain.study.dto.response;
+
+import com.jj.swm.domain.study.entity.StudyTag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StudyTagInquiryResponse {
+
+    private Long studyTagId;
+
+    private String name;
+
+    public static StudyTagInquiryResponse from(StudyTag studyTag) {
+        return StudyTagInquiryResponse.builder()
+                .studyTagId(studyTag.getId())
+                .name(studyTag.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/entity/Study.java
+++ b/src/main/java/com/jj/swm/domain/study/entity/Study.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -60,6 +62,9 @@ public class Study extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "study")
+    private List<StudyTag> studyTags = new ArrayList<>();
 
     public static Study of(User user, StudyCreateRequest createRequest) {
         return Study.builder()

--- a/src/main/java/com/jj/swm/domain/study/enums/SortCriteria.java
+++ b/src/main/java/com/jj/swm/domain/study/enums/SortCriteria.java
@@ -2,5 +2,5 @@ package com.jj.swm.domain.study.enums;
 
 public enum SortCriteria {
 
-    LIKE, NEWEST, OLDEST
+    LIKE, NEWEST
 }

--- a/src/main/java/com/jj/swm/domain/study/enums/SortCriteria.java
+++ b/src/main/java/com/jj/swm/domain/study/enums/SortCriteria.java
@@ -1,0 +1,6 @@
+package com.jj.swm.domain.study.enums;
+
+public enum SortCriteria {
+
+    LIKE, NEWEST, OLDEST
+}

--- a/src/main/java/com/jj/swm/domain/study/repository/CustomStudyBookmarkRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/CustomStudyBookmarkRepository.java
@@ -1,0 +1,11 @@
+package com.jj.swm.domain.study.repository;
+
+import com.jj.swm.domain.study.dto.StudyBookmarkInfo;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CustomStudyBookmarkRepository {
+
+    List<StudyBookmarkInfo> findAllByUserIdAndStudyIds(UUID userId, List<Long> studyIds);
+}

--- a/src/main/java/com/jj/swm/domain/study/repository/CustomStudyBookmarkRepositoryImpl.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/CustomStudyBookmarkRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.jj.swm.domain.study.repository;
+
+import com.jj.swm.domain.study.dto.QStudyBookmarkInfo;
+import com.jj.swm.domain.study.dto.StudyBookmarkInfo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.jj.swm.domain.study.entity.QStudy.study;
+import static com.jj.swm.domain.study.entity.QStudyBookmark.studyBookmark;
+import static com.jj.swm.domain.user.entity.QUser.user;
+
+@RequiredArgsConstructor
+public class CustomStudyBookmarkRepositoryImpl implements CustomStudyBookmarkRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<StudyBookmarkInfo> findAllByUserIdAndStudyIds(UUID userId, List<Long> studyIds) {
+        return jpaQueryFactory.select(new QStudyBookmarkInfo(study.id, studyBookmark.id))
+                .from(studyBookmark)
+                .join(studyBookmark.study, study)
+                .join(studyBookmark.user, user)
+                .where(user.id.eq(userId), study.id.in(studyIds))
+                .fetch();
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepository.java
@@ -2,13 +2,10 @@ package com.jj.swm.domain.study.repository;
 
 import com.jj.swm.domain.study.dto.StudyInquiryCondition;
 import com.jj.swm.domain.study.entity.Study;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomStudyRepository {
 
-    List<Study> findAllWithUserAndTags(Pageable pageable, StudyInquiryCondition inquiryConditionRequest);
-
-    Long countTotal(StudyInquiryCondition inquiryConditionRequest);
+    List<Study> findAllWithUserAndTags(int pageSize, StudyInquiryCondition inquiryCondition);
 }

--- a/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepository.java
@@ -1,0 +1,14 @@
+package com.jj.swm.domain.study.repository;
+
+import com.jj.swm.domain.study.dto.StudyInquiryCondition;
+import com.jj.swm.domain.study.entity.Study;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomStudyRepository {
+
+    List<Study> findAllWithUserAndTags(Pageable pageable, StudyInquiryCondition inquiryConditionRequest);
+
+    Long countTotal(StudyInquiryCondition inquiryConditionRequest);
+}

--- a/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.jj.swm.domain.study.repository;
+
+import com.jj.swm.domain.study.dto.StudyInquiryCondition;
+import com.jj.swm.domain.study.entity.Study;
+import com.jj.swm.domain.study.entity.StudyCategory;
+import com.jj.swm.domain.study.entity.StudyStatus;
+import com.jj.swm.domain.study.enums.SortCriteria;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static com.jj.swm.domain.study.entity.QStudy.study;
+
+
+@RequiredArgsConstructor
+public class CustomStudyRepositoryImpl implements CustomStudyRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Study> findAllWithUserAndTags(Pageable pageable, StudyInquiryCondition inquiryConditionRequest) {
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(inquiryConditionRequest.getSortCriteria());
+
+        List<Long> ids = jpaQueryFactory.select(study.id)
+                .from(study)
+                .where(
+                        studyCategoryEq(inquiryConditionRequest.getCategory()),
+                        studyStatusEq(inquiryConditionRequest.getStatus())
+                )
+                .orderBy(orderSpecifier)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return jpaQueryFactory.selectFrom(study)
+                .join(study.user)
+                .fetchJoin()
+                .leftJoin(study.studyTags)
+                .fetchJoin()
+                .where(study.id.in(ids))
+                .orderBy(orderSpecifier)
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public Long countTotal(StudyInquiryCondition inquiryConditionRequest) {
+        return jpaQueryFactory.select(study.count())
+                .from(study)
+                .where(
+                        studyCategoryEq(inquiryConditionRequest.getCategory()),
+                        studyStatusEq(inquiryConditionRequest.getStatus())
+                )
+                .fetchOne();
+    }
+
+    private BooleanBuilder studyCategoryEq(StudyCategory category) {
+        return this.nullSafeBuilder(() -> study.category.eq(category));
+    }
+
+    private BooleanBuilder studyStatusEq(StudyStatus status) {
+        return this.nullSafeBuilder(() -> study.status.eq(status));
+    }
+
+    private BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {
+        try {
+            return new BooleanBuilder(f.get());
+        } catch (IllegalArgumentException e) {
+            return new BooleanBuilder();
+        }
+    }
+
+    private OrderSpecifier<?> createOrderSpecifier(SortCriteria sortCriteria) {
+        return switch (sortCriteria != null ? sortCriteria : SortCriteria.NEWEST) {
+            case SortCriteria.LIKE -> new OrderSpecifier<>(Order.DESC, study.likeCount);
+            case SortCriteria.OLDEST -> new OrderSpecifier<>(Order.ASC, study.id);
+            case SortCriteria.NEWEST -> new OrderSpecifier<>(Order.DESC, study.id);
+        };
+    }
+}

--- a/src/main/java/com/jj/swm/domain/study/repository/StudyBookmarkRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/StudyBookmarkRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface StudyBookmarkRepository extends JpaRepository<StudyBookmark, Long> {
+public interface StudyBookmarkRepository extends JpaRepository<StudyBookmark, Long>, CustomStudyBookmarkRepository {
 
     @Query("select b from StudyBookmark b join fetch b.user where b.id = ?1")
     Optional<StudyBookmark> findWithUserById(Long bookmarkId);

--- a/src/main/java/com/jj/swm/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/repository/StudyRepository.java
@@ -3,5 +3,5 @@ package com.jj.swm.domain.study.repository;
 import com.jj.swm.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyRepository extends JpaRepository<Study, Long> {
+public interface StudyRepository extends JpaRepository<Study, Long>, CustomStudyRepository {
 }

--- a/src/main/java/com/jj/swm/domain/study/service/StudyQueryService.java
+++ b/src/main/java/com/jj/swm/domain/study/service/StudyQueryService.java
@@ -1,0 +1,57 @@
+package com.jj.swm.domain.study.service;
+
+import com.jj.swm.domain.study.dto.StudyBookmarkInfo;
+import com.jj.swm.domain.study.dto.StudyInquiryCondition;
+import com.jj.swm.domain.study.dto.response.StudyInquiryResponse;
+import com.jj.swm.domain.study.entity.Study;
+import com.jj.swm.domain.study.repository.StudyBookmarkRepository;
+import com.jj.swm.domain.study.repository.StudyRepository;
+import com.jj.swm.global.common.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyQueryService {
+
+    private final StudyRepository studyRepository;
+    private final StudyBookmarkRepository studyBookmarkRepository;
+
+    public PageResponse<StudyInquiryResponse> getList(
+            UUID userId,
+            int pageNo,
+            int pageSize,
+            StudyInquiryCondition inquiryCondition
+    ) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize);
+
+        List<Study> studies = studyRepository.findAllWithUserAndTags(pageable, inquiryCondition);
+
+        List<Long> studyIds = studies.stream()
+                .map(Study::getId)
+                .toList();
+
+        Map<Long, Long> bookmarkIdByStudyId = userId != null
+                ? studyBookmarkRepository.findAllByUserIdAndStudyIds(userId, studyIds)
+                    .stream()
+                    .collect(Collectors.toMap(StudyBookmarkInfo::getId, StudyBookmarkInfo::getStudyId))
+                : Collections.emptyMap();
+
+        List<StudyInquiryResponse> inquiryResponses = studies.stream()
+                .map(study -> StudyInquiryResponse.of(study, bookmarkIdByStudyId.getOrDefault(study.getId(), null)))
+                .toList();
+
+        Long totalStudies = studyRepository.countTotal(inquiryCondition);
+
+        return PageResponse.of(new PageImpl<>(inquiryResponses, pageable, totalStudies));
+    }
+}

--- a/src/main/java/com/jj/swm/global/common/dto/PageResponse.java
+++ b/src/main/java/com/jj/swm/global/common/dto/PageResponse.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
 public class PageResponse<D> {
     private int numberOfElements;
     private int totalPages;
-    private long totalElements;
+        private long totalElements;
     private boolean hasNext;
     private List<D> data;
 
@@ -25,6 +25,16 @@ public class PageResponse<D> {
                 entity.getTotalElements(),
                 entity.hasNext(),
                 dto
+        );
+    }
+
+    public static <D> PageResponse<D> of(Page<D> dto) {
+        return new PageResponse<>(
+                dto.getNumberOfElements(),
+                dto.getTotalPages(),
+                dto.getTotalElements(),
+                dto.hasNext(),
+                dto.getContent()
         );
     }
 

--- a/src/main/java/com/jj/swm/global/common/dto/PageResponse.java
+++ b/src/main/java/com/jj/swm/global/common/dto/PageResponse.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
 public class PageResponse<D> {
     private int numberOfElements;
     private int totalPages;
-        private long totalElements;
+    private long totalElements;
     private boolean hasNext;
     private List<D> data;
 
@@ -28,13 +28,13 @@ public class PageResponse<D> {
         );
     }
 
-    public static <D> PageResponse<D> of(Page<D> dto) {
+    public static <D> PageResponse<D> of(List<D> dto, boolean hasNext) {
         return new PageResponse<>(
-                dto.getNumberOfElements(),
-                dto.getTotalPages(),
-                dto.getTotalElements(),
-                dto.hasNext(),
-                dto.getContent()
+                dto.size(),
+                -1,
+                -1,
+                hasNext,
+                dto
         );
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ springdoc:
 logging:
   level:
     org.openqa.selenium.devtools.CdpVersionFinder: ERROR
+
+study:
+  page:
+    size: 20


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 요약
<!-- 이 PR이 해결하는 문제나 추가하는 기능을 한 문장으로 설명해주세요 -->
스터디 목록 조회 api 추가

## ✨ 수정사항
<!-- 주요 수정사항을 항목별로 설명해주세요 -->
- Study - StudyTag 양방향 관계 설정
- 커서 기반 페이지네이션을 통한 스터디 목록 조회 api 추가
- PageResponse에 dto를 받는 정적 팩토리 메소드 추가
- Study, StudyBookmark QueryDSL 추가
- application.yml에 study pageSize 속성 추가

## 📝 PR 타입
- [x] 🆕 신규 기능
- [ ] 🐛 버그 수정
- [ ] 🔨 리팩토링
- [ ] 📚 문서 수정
- [ ] 🔧 설정 변경

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->