### PR TITLE
[FEAT/SWM-248] 스터디 룸 예약 정보 수정 API 개발

### DIFF
--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationCommandController.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationCommandController.java
@@ -1,13 +1,13 @@
 package com.jj.swm.domain.studyroom.reservation.controller;
 
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
 import com.jj.swm.domain.studyroom.reservation.service.StudyRoomReservationCommandService;
 import com.jj.swm.global.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.UUID;
@@ -21,8 +21,20 @@ public class StudyRoomReservationCommandController {
     private final StudyRoomReservationCommandService commandService;
 
     @PostMapping("/v1/studyroom/reservation")
-    public ApiResponse<Void> createStudyRoomReservation(CreateStudyRoomReservationRequest request, Principal principal){
+    public ApiResponse<Void> createStudyRoomReservation(
+            @Valid @RequestBody CreateStudyRoomReservationRequest request, Principal principal
+    ) {
         commandService.createStudyRoomReservationAndSendSms(request, UUID.fromString(principal.getName()));
+
+        return ApiResponse.created(null);
+    }
+
+    @PatchMapping("/v1/studyroom/reservation/owner/{studyRoomReservationInfoId}")
+    public ApiResponse<Void> updateStudyRoomReservationApprovalStatus(
+            @Valid @RequestBody UpdateStudyRoomReservationApprovalStatusRequest request,
+            @PathVariable("studyRoomReservationInfoId") Long studyRoomReservationInfoId
+    ) {
+        commandService.updateStudyRoomReservationApprovalStatusAndSendSms(request, studyRoomReservationInfoId);
 
         return ApiResponse.created(null);
     }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationCommandController.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationCommandController.java
@@ -2,6 +2,7 @@ package com.jj.swm.domain.studyroom.reservation.controller;
 
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.service.StudyRoomReservationCommandService;
 import com.jj.swm.global.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,12 +30,27 @@ public class StudyRoomReservationCommandController {
         return ApiResponse.created(null);
     }
 
-    @PatchMapping("/v1/studyroom/reservation/owner/{studyRoomReservationInfoId}")
+    @PatchMapping("/v1/studyroom/reservation/status/{studyRoomReservationInfoId}")
     public ApiResponse<Void> updateStudyRoomReservationApprovalStatus(
             @Valid @RequestBody UpdateStudyRoomReservationApprovalStatusRequest request,
             @PathVariable("studyRoomReservationInfoId") Long studyRoomReservationInfoId
     ) {
         commandService.updateStudyRoomReservationApprovalStatusAndSendSms(request, studyRoomReservationInfoId);
+
+        return ApiResponse.created(null);
+    }
+
+    @PatchMapping("/v1/studyroom/reservation/{studyRoomReservationInfoId}")
+    public ApiResponse<Void> updateStudyRoomReservationApprovalStatus(
+            @Valid @RequestBody UpdateStudyRoomReservationRequest request,
+            @PathVariable("studyRoomReservationInfoId") Long studyRoomReservationInfoId,
+            Principal principal
+    ) {
+        commandService.updateStudyRoomReservation(
+                request,
+                studyRoomReservationInfoId,
+                UUID.fromString(principal.getName())
+        );
 
         return ApiResponse.created(null);
     }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationQueryController.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/controller/StudyRoomReservationQueryController.java
@@ -1,0 +1,15 @@
+package com.jj.swm.domain.studyroom.reservation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "StudyRoomReservationInfo", description = "<b>[스터디 룸 예약]</b> API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class StudyRoomReservationQueryController {
+
+
+}

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/event/StudyRoomReservationRequestEvent.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/event/StudyRoomReservationRequestEvent.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudyRoomReservationRequestEvent {
 
-    private Long studyRoomReservationInfoId;
     private String reserverName;
     private String reserverPhoneNumber;
     private Integer headcount;
@@ -21,8 +20,11 @@ public class StudyRoomReservationRequestEvent {
     private int maxHeadcount;
     private String reservationOption;
     private int pricePerHour;
+    private String reservationToken;
 
-    public static StudyRoomReservationRequestEvent from(StudyRoomReservationInfo studyRoomReservationInfo) {
+    public static StudyRoomReservationRequestEvent of(
+            StudyRoomReservationInfo studyRoomReservationInfo, String reservationToken
+    ) {
         return StudyRoomReservationRequestEvent.builder()
                 .reserverName(studyRoomReservationInfo.getReserverName())
                 .reserverPhoneNumber(studyRoomReservationInfo.getReserverPhoneNumber())
@@ -33,6 +35,7 @@ public class StudyRoomReservationRequestEvent {
                 .maxHeadcount(studyRoomReservationInfo.getStudyRoomReserveType().getMaxHeadcount())
                 .reservationOption(studyRoomReservationInfo.getStudyRoomReserveType().getReservationOption())
                 .pricePerHour(studyRoomReservationInfo.getStudyRoomReserveType().getPricePerHour())
+                .reservationToken(reservationToken)
                 .build();
     }
 }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/event/StudyRoomReservationResponseEvent.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/event/StudyRoomReservationResponseEvent.java
@@ -1,0 +1,41 @@
+package com.jj.swm.domain.studyroom.reservation.dto.event;
+
+import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StudyRoomReservationResponseEvent {
+
+    private String title;
+    private String reservationOption;
+    private String reserverName;
+    private String reserverPhoneNumber;
+    private String roomAdminPhoneNumber;
+    private Integer headcount;
+    private String memo;
+    private LocalDateTime checkInTime;
+    private LocalDateTime checkOutTime;
+    private Integer usageTime;
+    private int totalPrice;
+
+    public static StudyRoomReservationResponseEvent from(StudyRoomReservationInfo studyRoomReservationInfo) {
+        return StudyRoomReservationResponseEvent.builder()
+                .title(studyRoomReservationInfo.getStudyRoom().getTitle())
+                .reservationOption(studyRoomReservationInfo.getStudyRoomReserveType().getReservationOption())
+                .reserverName(studyRoomReservationInfo.getReserverName())
+                .reserverPhoneNumber(studyRoomReservationInfo.getReserverPhoneNumber())
+                .roomAdminPhoneNumber(studyRoomReservationInfo.getStudyRoom().getPhoneNumber())
+                .headcount(studyRoomReservationInfo.getHeadcount())
+                .memo(studyRoomReservationInfo.getMemo())
+                .checkInTime(studyRoomReservationInfo.getCheckInTime())
+                .checkOutTime(studyRoomReservationInfo.getCheckOutTime())
+                .usageTime(studyRoomReservationInfo.getUsageTime())
+                .totalPrice(studyRoomReservationInfo.getTotalPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/CreateStudyRoomReservationRequest.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/CreateStudyRoomReservationRequest.java
@@ -14,6 +14,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateStudyRoomReservationRequest {
 
+    @NotNull
+    private Long studyRoomReserveTypeId;
+
     @NotBlank
     private String reserverName;
 
@@ -33,7 +36,4 @@ public class CreateStudyRoomReservationRequest {
     @NotNull
     @Positive
     private Integer usageTime;
-
-    @NotNull
-    private Long studyRoomReserveTypeId;
 }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/UpdateStudyRoomReservationApprovalStatusRequest.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/UpdateStudyRoomReservationApprovalStatusRequest.java
@@ -1,0 +1,15 @@
+package com.jj.swm.domain.studyroom.reservation.dto.request;
+
+import com.jj.swm.domain.studyroom.reservation.entity.ApprovalStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateStudyRoomReservationApprovalStatusRequest {
+
+    @NotNull
+    private ApprovalStatus approvalStatus;
+}

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/UpdateStudyRoomReservationRequest.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/dto/request/UpdateStudyRoomReservationRequest.java
@@ -1,0 +1,36 @@
+package com.jj.swm.domain.studyroom.reservation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateStudyRoomReservationRequest {
+
+    @NotBlank
+    private String reserverName;
+
+    @NotBlank
+    private String reserverPhoneNumber;
+
+    @NotNull
+    @Positive
+    private Integer headcount;
+
+    private String memo;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime checkInTime;
+
+    @NotNull
+    @Positive
+    private Integer usageTime;
+}

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
@@ -3,6 +3,7 @@ package com.jj.swm.domain.studyroom.reservation.entity;
 import com.jj.swm.domain.studyroom.core.entity.StudyRoom;
 import com.jj.swm.domain.studyroom.core.entity.StudyRoomReserveType;
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationRequest;
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -74,6 +75,17 @@ public class StudyRoomReservationInfo extends BaseTimeEntity {
 
     public void modifyApprovalStatus(ApprovalStatus approvalStatus) {
         this.approvalStatus = approvalStatus;
+    }
+
+    public void modifyStudyRoomReservationInfo(UpdateStudyRoomReservationRequest request) {
+        this.reserverName = request.getReserverName();
+        this.reserverPhoneNumber = request.getReserverPhoneNumber();
+        this.headcount = request.getHeadcount();
+        this.memo = request.getMemo();
+        this.checkInTime = request.getCheckInTime();
+        this.checkOutTime = request.getCheckInTime().plusHours(request.getUsageTime());
+        this.usageTime = request.getUsageTime();
+        this.totalPrice = studyRoomReserveType.getPricePerHour() * request.getUsageTime();
     }
 
     public static StudyRoomReservationInfo of(

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
@@ -54,6 +54,9 @@ public class StudyRoomReservationInfo extends BaseTimeEntity {
     @JdbcType(value = PostgreSQLEnumJdbcType.class)
     private ApprovalStatus approvalStatus;
 
+    @Column(name = "total_price", nullable = false)
+    private Integer totalPrice;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -87,6 +90,7 @@ public class StudyRoomReservationInfo extends BaseTimeEntity {
                 .checkInTime(request.getCheckInTime())
                 .checkOutTime(request.getCheckInTime().plusHours(request.getUsageTime()))
                 .usageTime(request.getUsageTime())
+                .totalPrice(studyRoomReserveType.getPricePerHour() * request.getUsageTime())
                 .approvalStatus(ApprovalStatus.WAITING)
                 .user(user)
                 .studyRoomReserveType(studyRoomReserveType)

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/entity/StudyRoomReservationInfo.java
@@ -69,6 +69,10 @@ public class StudyRoomReservationInfo extends BaseTimeEntity {
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
 
+    public void modifyApprovalStatus(ApprovalStatus approvalStatus) {
+        this.approvalStatus = approvalStatus;
+    }
+
     public static StudyRoomReservationInfo of(
             CreateStudyRoomReservationRequest request,
             StudyRoom studyRoom,

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/repository/StudyRoomReservationInfoRepository.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/repository/StudyRoomReservationInfoRepository.java
@@ -2,6 +2,12 @@ package com.jj.swm.domain.studyroom.reservation.repository;
 
 import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface StudyRoomReservationInfoRepository extends JpaRepository<StudyRoomReservationInfo, Long> {
+
+    @Query("select s from StudyRoomReservationInfo s left join fetch s.studyRoom where s.id = ?1")
+    Optional<StudyRoomReservationInfo> findByIdWithStudyRoom(Long studyRoomReservationInfoId);
 }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/repository/StudyRoomReservationInfoRepository.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/repository/StudyRoomReservationInfoRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface StudyRoomReservationInfoRepository extends JpaRepository<StudyRoomReservationInfo, Long> {
 
     @Query("select s from StudyRoomReservationInfo s left join fetch s.studyRoom where s.id = ?1")
     Optional<StudyRoomReservationInfo> findByIdWithStudyRoom(Long studyRoomReservationInfoId);
+
+    Optional<StudyRoomReservationInfo> findByIdAndUserId(Long studyRoomReservationInfoId, UUID userId);
 }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
@@ -8,6 +8,7 @@ import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationReq
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationResponseEvent;
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
 import com.jj.swm.domain.studyroom.reservation.repository.StudyRoomReservationInfoRepository;
 import com.jj.swm.domain.user.core.entity.User;
@@ -67,13 +68,25 @@ public class StudyRoomReservationCommandService {
     public void updateStudyRoomReservationApprovalStatusAndSendSms(
             UpdateStudyRoomReservationApprovalStatusRequest request, Long studyRoomReservationInfoId
     ){
-        StudyRoomReservationInfo studyRoomReservationInfo = reservationInfoRepository.findByIdWithStudyRoom(studyRoomReservationInfoId)
+        StudyRoomReservationInfo reservationInfo = reservationInfoRepository.findByIdWithStudyRoom(studyRoomReservationInfoId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "StudyRoomReservationInfo Not Found"));
 
-        studyRoomReservationInfo.modifyApprovalStatus(request.getApprovalStatus());
+        reservationInfo.modifyApprovalStatus(request.getApprovalStatus());
 
-        Events.send(StudyRoomReservationResponseEvent.from(studyRoomReservationInfo));
+        Events.send(StudyRoomReservationResponseEvent.from(reservationInfo));
         // TODO: 알림톡 전송 작업
+    }
+
+    @Transactional
+    public void updateStudyRoomReservation(
+            UpdateStudyRoomReservationRequest request,
+            Long studyRoomReservationInfoId,
+            UUID userId
+    ) {
+        StudyRoomReservationInfo reservationInfo = reservationInfoRepository.findByIdAndUserId(studyRoomReservationInfoId, userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "StudyRoomReservationInfo Not Found"));
+
+        reservationInfo.modifyStudyRoomReservationInfo(request);
     }
 
     private String insertReservationToken(Long studyRoomReservationInfoId) {

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
@@ -5,7 +5,9 @@ import com.jj.swm.domain.studyroom.core.entity.StudyRoomReserveType;
 import com.jj.swm.domain.studyroom.core.repository.StudyRoomRepository;
 import com.jj.swm.domain.studyroom.core.repository.StudyRoomReserveTypeRepository;
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationRequestEvent;
+import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationResponseEvent;
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
 import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
 import com.jj.swm.domain.studyroom.reservation.repository.StudyRoomReservationInfoRepository;
 import com.jj.swm.domain.user.core.entity.User;
@@ -49,6 +51,19 @@ public class StudyRoomReservationCommandService {
         studyRoomReservationInfo = reservationInfoRepository.save(studyRoomReservationInfo);
 
         Events.send(StudyRoomReservationRequestEvent.from(studyRoomReservationInfo));
+        // TODO: 알림톡 전송 작업
+    }
+
+    @Transactional
+    public void updateStudyRoomReservationApprovalStatusAndSendSms(
+            UpdateStudyRoomReservationApprovalStatusRequest request, Long studyRoomReservationInfoId
+    ){
+        StudyRoomReservationInfo studyRoomReservationInfo = reservationInfoRepository.findByIdWithStudyRoom(studyRoomReservationInfoId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "StudyRoomReservationInfo Not Found"));
+
+        studyRoomReservationInfo.modifyApprovalStatus(request.getApprovalStatus());
+
+        Events.send(StudyRoomReservationResponseEvent.from(studyRoomReservationInfo));
         // TODO: 알림톡 전송 작업
     }
 }

--- a/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
+++ b/src/main/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandService.java
@@ -13,8 +13,12 @@ import com.jj.swm.domain.studyroom.reservation.repository.StudyRoomReservationIn
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.domain.user.core.repository.UserRepository;
 import com.jj.swm.global.common.enums.ErrorCode;
+import com.jj.swm.global.common.enums.ExpirationTime;
+import com.jj.swm.global.common.enums.RedisPrefix;
 import com.jj.swm.global.event.Events;
 import com.jj.swm.global.exception.GlobalException;
+import com.jj.swm.global.security.jwt.JwtProvider;
+import com.jj.swm.global.security.jwt.TokenRedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +28,9 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class StudyRoomReservationCommandService {
+
+    private final TokenRedisService tokenRedisService;
+    private final JwtProvider jwtProvider;
 
     private final StudyRoomReservationInfoRepository reservationInfoRepository;
     private final StudyRoomRepository studyRoomRepository;
@@ -50,7 +57,9 @@ public class StudyRoomReservationCommandService {
 
         studyRoomReservationInfo = reservationInfoRepository.save(studyRoomReservationInfo);
 
-        Events.send(StudyRoomReservationRequestEvent.from(studyRoomReservationInfo));
+        String reservationToken = insertReservationToken(studyRoomReservationInfo.getId());
+
+        Events.send(StudyRoomReservationRequestEvent.of(studyRoomReservationInfo, reservationToken));
         // TODO: 알림톡 전송 작업
     }
 
@@ -65,5 +74,18 @@ public class StudyRoomReservationCommandService {
 
         Events.send(StudyRoomReservationResponseEvent.from(studyRoomReservationInfo));
         // TODO: 알림톡 전송 작업
+    }
+
+    private String insertReservationToken(Long studyRoomReservationInfoId) {
+        String reservationToken = jwtProvider.generateTokenForReservation(
+                studyRoomReservationInfoId, ExpirationTime.STUDYROOM_RESERVATION_TOKEN.getValue()
+        );
+
+        tokenRedisService.saveReservationToken(
+                RedisPrefix.STUDYROOM_RESERVATION_TOKEN.getValue() + reservationToken,
+                studyRoomReservationInfoId.toString()
+        );
+
+        return reservationToken;
     }
 }

--- a/src/main/java/com/jj/swm/global/common/enums/ExpirationTime.java
+++ b/src/main/java/com/jj/swm/global/common/enums/ExpirationTime.java
@@ -9,7 +9,8 @@ public enum ExpirationTime {
     EMAIL(600000), // 10분
     EMAIL_VERIFIED(30 * 60 * 1000L), // 30분
     ACCESS_TOKEN(30 * 60 * 1000L), // 30분
-    REFRESH_TOKEN(15 * 24 * 60 * 60 * 1000L); // 15일
+    REFRESH_TOKEN(15 * 24 * 60 * 60 * 1000L), // 15일
+    STUDYROOM_RESERVATION_TOKEN(3 * 24 * 60 * 1000L); // 3일
 
     private final long value;
 }

--- a/src/main/java/com/jj/swm/global/common/enums/RedisPrefix.java
+++ b/src/main/java/com/jj/swm/global/common/enums/RedisPrefix.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum RedisPrefix {
     EMAIL_AUTH_CODE("email_auth_code:"),
     PASSWORD_AUTH_CODE("password_auth_code:"),
-    ID_AUTH_CODE("id_auth_code:");
+    ID_AUTH_CODE("id_auth_code:"),
+    STUDYROOM_RESERVATION_TOKEN("studyroom_reservation_token:");
 
     private final String value;
 }

--- a/src/main/java/com/jj/swm/global/common/service/KakaoNotificationService.java
+++ b/src/main/java/com/jj/swm/global/common/service/KakaoNotificationService.java
@@ -1,6 +1,7 @@
 package com.jj.swm.global.common.service;
 
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationRequestEvent;
+import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationResponseEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,11 @@ import java.util.concurrent.CompletableFuture;
 @RequiredArgsConstructor
 public class KakaoNotificationService {
     public CompletableFuture<Boolean> sendStudyRoomReservationRequestNotification(StudyRoomReservationRequestEvent event) {
+        log.info("카카오 알림 전송 성공, time: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+        return CompletableFuture.completedFuture(true);
+    }
+
+    public CompletableFuture<Boolean> sendStudyRoomReservationResponseNotification(StudyRoomReservationResponseEvent event) {
         log.info("카카오 알림 전송 성공, time: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         return CompletableFuture.completedFuture(true);
     }

--- a/src/main/java/com/jj/swm/global/config/SecurityConfig.java
+++ b/src/main/java/com/jj/swm/global/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                         .requestMatchers(AllowedPaths.getAllowedPaths()).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/studyroom/user/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/studyroom/**").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/studyroom/reservation/owner/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/study/user/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/study/**", "/api/v1/comment/**").permitAll()
                         .requestMatchers("/api/v1/files/**").authenticated()

--- a/src/main/java/com/jj/swm/global/config/SecurityConfig.java
+++ b/src/main/java/com/jj/swm/global/config/SecurityConfig.java
@@ -60,12 +60,11 @@ public class SecurityConfig {
                         .requestMatchers(AllowedPaths.getAllowedPaths()).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/studyroom/user/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/studyroom/**").permitAll()
-                        .requestMatchers(HttpMethod.PATCH, "/api/v1/studyroom/reservation/owner/**").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/studyroom/reservation/status/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/study/user/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/study/**", "/api/v1/comment/**").permitAll()
                         .requestMatchers("/api/v1/files/**").authenticated()
                         .anyRequest().authenticated()
-
                 )
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/jj/swm/global/event/handler/StudyRoomReservationEventHandler.java
+++ b/src/main/java/com/jj/swm/global/event/handler/StudyRoomReservationEventHandler.java
@@ -1,6 +1,7 @@
 package com.jj.swm.global.event.handler;
 
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationRequestEvent;
+import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationResponseEvent;
 import com.jj.swm.global.common.service.KakaoNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,17 @@ public class StudyRoomReservationEventHandler {
     @TransactionalEventListener(classes = StudyRoomReservationRequestEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     public void studyRoomReservationRequestEventAfterCommitHandler(StudyRoomReservationRequestEvent event) {
         kakaoNotificationService.sendStudyRoomReservationRequestNotification(event).thenAccept(success -> {
+            if(!success){
+                log.error("카카오 알림 전송 오류, time: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+            } else {
+                log.info("카카오 알림 전송 성공, time: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+            }
+        });
+    }
+
+    @TransactionalEventListener(classes = StudyRoomReservationResponseEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    public void studyRoomReservationResponseEventAfterCommitHandler(StudyRoomReservationResponseEvent event) {
+        kakaoNotificationService.sendStudyRoomReservationResponseNotification(event).thenAccept(success -> {
             if(!success){
                 log.error("카카오 알림 전송 오류, time: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
             } else {

--- a/src/main/java/com/jj/swm/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/jj/swm/global/security/jwt/JwtProvider.java
@@ -38,6 +38,9 @@ public class JwtProvider {
     @Value("${jwt.secret-key}")
     private String key;
 
+    @Value("${jwt.reservation-secret-key}")
+    private String reservationKey;
+
     @Value("${cookie.same-site}")
     private String cookieSameSite;
 
@@ -45,6 +48,7 @@ public class JwtProvider {
     private boolean cookieSecure;
 
     private SecretKey secretKey;
+    private SecretKey reservationSecretKey;
     private final TokenRedisService tokenRedisService;
 
     private static final String KEY_ROLE = "role";
@@ -55,6 +59,8 @@ public class JwtProvider {
     private void setSecretKey(){
         this.secretKey = new SecretKeySpec(
                 key.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.reservationSecretKey = new SecretKeySpec(
+                reservationKey.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
     public Token generateTokens(com.jj.swm.domain.user.core.entity.User user) {
@@ -72,6 +78,18 @@ public class JwtProvider {
 
     public String generateAccessToken(Authentication authentication) {
         return createToken(authentication, ExpirationTime.ACCESS_TOKEN.getValue());
+    }
+
+    public String generateTokenForReservation(Long reservationId, long expireTime) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expireTime);
+
+        return Jwts.builder()
+                .subject(reservationId.toString()) // 예약 ID를 subject로 설정
+                .issuedAt(now)
+                .expiration(expiredDate)
+                .signWith(reservationSecretKey, Jwts.SIG.HS512)
+                .compact();
     }
 
     public ResponseCookie generateRefreshToken(Authentication authentication) {

--- a/src/main/java/com/jj/swm/global/security/jwt/TokenRedisService.java
+++ b/src/main/java/com/jj/swm/global/security/jwt/TokenRedisService.java
@@ -2,6 +2,7 @@ package com.jj.swm.global.security.jwt;
 
 import com.jj.swm.global.common.enums.ErrorCode;
 import com.jj.swm.global.common.enums.ExpirationTime;
+import com.jj.swm.global.exception.GlobalException;
 import com.jj.swm.global.exception.auth.TokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -23,6 +24,20 @@ public class TokenRedisService {
     public void saveAccessTokenForLogout(String accessToken){
         stringRedisTemplate.opsForValue()
                 .set(accessToken, "logout", Duration.ofMillis(ExpirationTime.ACCESS_TOKEN.getValue()));
+    }
+
+    public void saveReservationToken(String reservationId, String reservationToken) {
+        stringRedisTemplate.opsForValue()
+                .set(reservationId, reservationToken, Duration.ofMillis(ExpirationTime.STUDYROOM_RESERVATION_TOKEN.getValue()));
+    }
+
+    public Long findReservationIdByReservationToken(String reservationToken) {
+        String reservationId = stringRedisTemplate.opsForValue().get(reservationToken);
+
+        if(reservationId == null)
+            throw new GlobalException(ErrorCode.NOT_FOUND, "Reservation Token Not Found");
+
+        return Long.parseLong(reservationId);
     }
 
     public String findByUserIdOrThrow(String userId) {

--- a/src/main/resources/db/migration/V20250324120422__alter_table_study_room_reservation_info_add_column_total_price.sql
+++ b/src/main/resources/db/migration/V20250324120422__alter_table_study_room_reservation_info_add_column_total_price.sql
@@ -1,0 +1,2 @@
+alter table study_room_reservation_info
+add column total_price integer not null default 0;

--- a/src/test/java/com/jj/swm/domain/studyroom/reservation/fixture/StudyRoomReservationInfoFixture.java
+++ b/src/test/java/com/jj/swm/domain/studyroom/reservation/fixture/StudyRoomReservationInfoFixture.java
@@ -1,0 +1,35 @@
+package com.jj.swm.domain.studyroom.reservation.fixture;
+
+import com.jj.swm.domain.studyroom.core.entity.StudyRoom;
+import com.jj.swm.domain.studyroom.core.entity.StudyRoomReserveType;
+import com.jj.swm.domain.studyroom.reservation.entity.ApprovalStatus;
+import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
+import com.jj.swm.domain.user.core.entity.User;
+
+import java.time.LocalDateTime;
+
+public class StudyRoomReservationInfoFixture {
+
+    public static StudyRoomReservationInfo create(
+            User user,
+            StudyRoom studyRoom,
+            StudyRoomReserveType reserveType
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return StudyRoomReservationInfo.builder()
+                .user(user)
+                .studyRoom(studyRoom)
+                .studyRoomReserveType(reserveType)
+                .reserverName("test")
+                .reserverPhoneNumber("010-1234-5678")
+                .checkInTime(now)
+                .checkOutTime(now.plusHours(3))
+                .approvalStatus(ApprovalStatus.WAITING)
+                .usageTime(3)
+                .headcount(1)
+                .memo("memo")
+                .totalPrice(9000)
+                .build();
+    }
+}

--- a/src/test/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandServiceIntegrationTest.java
@@ -9,12 +9,16 @@ import com.jj.swm.domain.studyroom.core.repository.StudyRoomRepository;
 import com.jj.swm.domain.studyroom.core.repository.StudyRoomReserveTypeRepository;
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationRequestEvent;
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
+import com.jj.swm.domain.studyroom.reservation.entity.ApprovalStatus;
 import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
+import com.jj.swm.domain.studyroom.reservation.fixture.StudyRoomReservationInfoFixture;
 import com.jj.swm.domain.studyroom.reservation.repository.StudyRoomReservationInfoRepository;
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.domain.user.core.fixture.UserFixture;
 import com.jj.swm.domain.user.core.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -52,7 +56,8 @@ class StudyRoomReservationCommandServiceIntegrationTest extends IntegrationConta
     }
 
     @Test
-    public void createStudyRoomReservationAndSendSms() throws Exception{
+    @DisplayName("스터디 룸 예약 신청을 생성하고 카카오톡 알림을 전달한다.")
+    public void createStudyRoomReservationAndSendSms_Success() throws Exception{
         //given
         LocalDateTime now = LocalDateTime.now();
 
@@ -78,5 +83,53 @@ class StudyRoomReservationCommandServiceIntegrationTest extends IntegrationConta
         assertEquals(now.plusHours(3), studyRoomReservationInfo.getCheckOutTime());
         verify(kakaoNotificationService, times(1))
                 .sendStudyRoomReservationRequestNotification(any(StudyRoomReservationRequestEvent.class));
+    }
+
+    @Test
+    @DisplayName("스터디 룸 예약 신청을 승인한다.")
+    public void updateStudyRoomReservationApprovalStatusAndSendSms_WhenApprove_Success() throws Exception{
+        //given
+        StudyRoomReservationInfo reservationInfo = StudyRoomReservationInfoFixture.create(
+                createReservationUser,
+                studyRoom,
+                studyRoomReserveType
+        );
+
+        reservationInfo = reservationInfoRepository.save(reservationInfo);
+
+        UpdateStudyRoomReservationApprovalStatusRequest request = UpdateStudyRoomReservationApprovalStatusRequest.builder()
+                .approvalStatus(ApprovalStatus.APPROVED)
+                .build();
+
+        //when
+        commandService.updateStudyRoomReservationApprovalStatusAndSendSms(request, reservationInfo.getId());
+
+        //then
+        reservationInfo = reservationInfoRepository.findById(reservationInfo.getId()).get();
+        assertEquals(ApprovalStatus.APPROVED, reservationInfo.getApprovalStatus());
+    }
+
+    @Test
+    @DisplayName("스터디 룸 예약 신청을 거부한다.")
+    public void updateStudyRoomReservationApprovalStatusAndSendSms_WhenRejected_Success() throws Exception{
+        //given
+        StudyRoomReservationInfo reservationInfo = StudyRoomReservationInfoFixture.create(
+                createReservationUser,
+                studyRoom,
+                studyRoomReserveType
+        );
+
+        reservationInfo = reservationInfoRepository.save(reservationInfo);
+
+        UpdateStudyRoomReservationApprovalStatusRequest request = UpdateStudyRoomReservationApprovalStatusRequest.builder()
+                .approvalStatus(ApprovalStatus.REJECTED)
+                .build();
+
+        //when
+        commandService.updateStudyRoomReservationApprovalStatusAndSendSms(request, reservationInfo.getId());
+
+        //then
+        reservationInfo = reservationInfoRepository.findById(reservationInfo.getId()).get();
+        assertEquals(ApprovalStatus.REJECTED, reservationInfo.getApprovalStatus());
     }
 }

--- a/src/test/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/studyroom/reservation/service/StudyRoomReservationCommandServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import com.jj.swm.domain.studyroom.core.repository.StudyRoomReserveTypeRepositor
 import com.jj.swm.domain.studyroom.reservation.dto.event.StudyRoomReservationRequestEvent;
 import com.jj.swm.domain.studyroom.reservation.dto.request.CreateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationApprovalStatusRequest;
+import com.jj.swm.domain.studyroom.reservation.dto.request.UpdateStudyRoomReservationRequest;
 import com.jj.swm.domain.studyroom.reservation.entity.ApprovalStatus;
 import com.jj.swm.domain.studyroom.reservation.entity.StudyRoomReservationInfo;
 import com.jj.swm.domain.studyroom.reservation.fixture.StudyRoomReservationInfoFixture;
@@ -17,12 +18,14 @@ import com.jj.swm.domain.studyroom.reservation.repository.StudyRoomReservationIn
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.domain.user.core.fixture.UserFixture;
 import com.jj.swm.domain.user.core.repository.UserRepository;
+import com.jj.swm.global.exception.GlobalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -131,5 +134,65 @@ class StudyRoomReservationCommandServiceIntegrationTest extends IntegrationConta
         //then
         reservationInfo = reservationInfoRepository.findById(reservationInfo.getId()).get();
         assertEquals(ApprovalStatus.REJECTED, reservationInfo.getApprovalStatus());
+    }
+
+    @Test
+    @DisplayName("스터디 룸 예약 신청 수정에 성공한다.")
+    public void updateStudyRoomReservation_Success() throws Exception{
+        //given
+        StudyRoomReservationInfo reservationInfo = StudyRoomReservationInfoFixture.create(
+                createReservationUser,
+                studyRoom,
+                studyRoomReserveType
+        );
+
+        reservationInfo = reservationInfoRepository.save(reservationInfo);
+
+        UpdateStudyRoomReservationRequest request = UpdateStudyRoomReservationRequest.builder()
+                .reserverName("tester2")
+                .reserverPhoneNumber("010-4567-8899")
+                .headcount(2)
+                .checkInTime(LocalDateTime.now())
+                .usageTime(2)
+                .build();
+
+        //when
+        commandService.updateStudyRoomReservation(request, reservationInfo.getId(), createReservationUser.getId());
+
+        //then
+        reservationInfo = reservationInfoRepository.findById(reservationInfo.getId()).get();
+        assertEquals("tester2", reservationInfo.getReserverName());
+        assertEquals("010-4567-8899", reservationInfo.getReserverPhoneNumber());
+        assertEquals(2, reservationInfo.getHeadcount());
+        assertEquals(2, reservationInfo.getUsageTime());
+    }
+
+    @Test
+    @DisplayName("스터디 룸 예약 신청자가 아니라면 수정에 실패한다.")
+    public void updateStudyRoomReservation_WhenNotReservationUser_ThenFail() throws Exception{
+        //given
+        StudyRoomReservationInfo reservationInfo = StudyRoomReservationInfoFixture.create(
+                createReservationUser,
+                studyRoom,
+                studyRoomReserveType
+        );
+
+        reservationInfo = reservationInfoRepository.save(reservationInfo);
+
+        UpdateStudyRoomReservationRequest request = UpdateStudyRoomReservationRequest.builder()
+                .reserverName("tester2")
+                .reserverPhoneNumber("010-4567-8899")
+                .headcount(2)
+                .checkInTime(LocalDateTime.now())
+                .usageTime(2)
+                .build();
+
+        //when & then
+        StudyRoomReservationInfo finalReservationInfo = reservationInfo;
+        assertThrows(GlobalException.class, () -> commandService.updateStudyRoomReservation(
+                request,
+                finalReservationInfo.getId(),
+                UUID.randomUUID())
+        );
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 요약
<!-- 이 PR이 해결하는 문제나 추가하는 기능을 한 문장으로 설명해주세요 -->
스터디 룸 예약 정보 수정 API 개발

## ✨ 수정사항
<!-- 주요 수정사항을 항목별로 설명해주세요 -->
- 스터디 룸 예약 승인/거절 API 개발
- 스터디 룸 예약 신청 시 알림톡에 전송될 토큰 생성 및 Redis  저장
- SecurityConfig에 관련 경로 인증 제외
- 스터디 룸 예약 정보 수정 API 개발
- 승인/거절에 따른 응답 이벤트 핸들러 생성
- 관련 테스트 코드 작성

## 📝 PR 타입
- [x] 🆕 신규 기능
- [ ] 🐛 버그 수정
- [x] 🔨 리팩토링
- [ ] 📚 문서 수정
- [x] 🔧 설정 변경
- [x] 📝 테스트 작성

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
