### PR TITLE
[HOTFIX/SWM-268]: 이미지 수정 시 이미지 개수 불러오지 않는 버그 수정

### DIFF
--- a/src/main/java/com/jj/swm/domain/study/core/service/StudyCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/core/service/StudyCommandService.java
@@ -196,8 +196,8 @@ public class StudyCommandService {
             List<Long> imageIdsToRemove = Optional.ofNullable(request.getImageIdsToRemove())
                     .orElse(Collections.emptyList());
 
-            int oldTagSize = studyTagRepository.countByStudyId(study.getId());
-            int newImageSize = oldTagSize + imageUrlsToAdd.size() - imageIdsToRemove.size();
+            int oldImageSize = studyImageRepository.countByStudyId(study.getId());
+            int newImageSize = oldImageSize + imageUrlsToAdd.size() - imageIdsToRemove.size();
 
             if (newImageSize < 0 || newImageSize > StudyConstants.IMAGE_LIMIT) {
                 throw new GlobalException(ErrorCode.NOT_VALID, "Image Limit Exceeded");


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 요약
<!-- 이 PR이 해결하는 문제나 추가하는 기능을 한 문장으로 설명해주세요 -->
이미지 수정 시 이미지 개수 불러오지 않는 버그 수정

## ✨ 수정사항
<!-- 주요 수정사항을 항목별로 설명해주세요 -->
- 이미지 수정 시 이미지 개수 불러오지 않는 버그 수정

## 📝 PR 타입
- [ ] 🆕 신규 기능
- [x] 🐛 버그 수정
- [ ] 🔨 리팩토링
- [ ] 📚 문서 수정
- [ ] 🔧 설정 변경
- [ ] 📝 테스트 작성

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
