### PR TITLE
[FIX/SWM-272]: 스터디 참여 관련 API 수정 작업

### DIFF
--- a/src/main/java/com/jj/swm/domain/study/core/service/StudyCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/core/service/StudyCommandService.java
@@ -1,5 +1,6 @@
 package com.jj.swm.domain.study.core.service;
 
+import com.google.common.collect.Lists;
 import com.jj.swm.domain.study.comment.repository.StudyStudyCommentRepository;
 import com.jj.swm.domain.study.constants.StudyConstants;
 import com.jj.swm.domain.study.core.dto.request.*;
@@ -9,12 +10,15 @@ import com.jj.swm.domain.study.core.entity.StudyBookmark;
 import com.jj.swm.domain.study.core.entity.StudyLike;
 import com.jj.swm.domain.study.core.repository.*;
 import com.jj.swm.domain.study.recruitmentposition.repository.RecruitmentPositionRepository;
+import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationLinkRepository;
+import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationRepository;
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.domain.user.core.repository.UserRepository;
 import com.jj.swm.global.common.enums.ErrorCode;
 import com.jj.swm.global.exception.GlobalException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -29,6 +33,9 @@ import static com.jj.swm.global.common.util.ListCheckUtils.isListPresent;
 @RequiredArgsConstructor
 public class StudyCommandService {
 
+    @Value("${spring.jpa.properties.hibernate.jdbc.batch_size}")
+    private int batchSize;
+
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
     private final StudyTagRepository studyTagRepository;
@@ -36,7 +43,9 @@ public class StudyCommandService {
     private final StudyImageRepository studyImageRepository;
     private final StudyBookmarkRepository studyBookmarkRepository;
     private final StudyStudyCommentRepository studyCommentRepository;
+    private final StudyParticipationRepository participationRepository;
     private final RecruitmentPositionRepository recruitmentPositionRepository;
+    private final StudyParticipationLinkRepository participationLinkRepository;
 
     @Transactional
     public void createStudy(CreateStudyRequest request, UUID userId) {
@@ -215,20 +224,32 @@ public class StudyCommandService {
     private void deleteStudyAndAssociations(Long studyId, Study study) {
         studyTagRepository.deleteAllByStudyId(studyId);
         studyImageRepository.deleteAllByStudyId(studyId);
-        recruitmentPositionRepository.deleteAllByStudyId(studyId);
         studyLikeRepository.deleteAllByStudyId(studyId);
         studyCommentRepository.deleteAllByStudyId(studyId);
         studyBookmarkRepository.deleteAllByStudyId(studyId);
+
+        List<Long> participationIds = participationRepository.findIdsByStudyId(studyId);
+        Lists.partition(participationIds, batchSize)
+                .forEach(participationLinkRepository::deleteAllByParticipationIds);
+        participationRepository.deleteAllByStudyId(studyId);
+        recruitmentPositionRepository.deleteAllByStudyId(studyId);
+
         studyRepository.delete(study);
     }
 
     public void deleteStudiesAndAssociations(List<Long> studyIds) {
         studyTagRepository.deleteAllByStudyIds(studyIds);
         studyImageRepository.deleteAllByStudyIds(studyIds);
-        recruitmentPositionRepository.deleteAllByStudyIds(studyIds);
         studyLikeRepository.deleteAllByStudyIds(studyIds);
         studyCommentRepository.deleteAllByStudyIds(studyIds);
         studyBookmarkRepository.deleteAllByStudyIds(studyIds);
+
+        List<Long> participationIds = participationRepository.findIdsByStudyIds(studyIds);
+        Lists.partition(participationIds, batchSize)
+                .forEach(participationLinkRepository::deleteAllByParticipationIds);
+        participationRepository.deleteAllByStudyIds(studyIds);
+        recruitmentPositionRepository.deleteAllByStudyIds(studyIds);
+
         studyRepository.deleteAllByStudyIds(studyIds);
     }
 

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/controller/RecruitmentPositionCommandController.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/controller/RecruitmentPositionCommandController.java
@@ -100,7 +100,7 @@ public class RecruitmentPositionCommandController {
     @PatchMapping("/v1/recruitment-position/participation/{participationId}/status")
     @Operation(
             summary = "스터디 참여 상태 수정",
-            description = "스터디 참여 상태를 수정합니다. 승인 시 kakaoId를 전송해줍니다."
+            description = "스터디 참여 상태를 수정합니다. 승인 시에만 kakaoId를 전송해줍니다."
     )
     public ApiResponse<UpdateStudyParticipationStatusResponse> updateStudyParticipationStatus(
             @Valid @RequestBody UpdateStudyParticipationStatusRequest request,
@@ -142,7 +142,11 @@ public class RecruitmentPositionCommandController {
     @DeleteMapping("/v1/recruitment-position/participation/{participationId}")
     @Operation(
             summary = "스터디 참여 삭제",
-            description = "스터디 참여를 삭제합니다. 승인된 참여 신청은 삭제가 불가능합니다."
+            description = """
+                    스터디 참여를 삭제합니다.
+                    승인된 참여 신청은 삭제가 불가능합니다.
+                    거절된 참여 신청을 삭제하면 3일 뒤에 재생성할 수 있습니다.
+                    """
     )
     public ApiResponse<Void> deleteStudyParticipation(
             @PathVariable("participationId") Long participationId, Principal principal

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/controller/RecruitmentPositionQueryController.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/controller/RecruitmentPositionQueryController.java
@@ -25,20 +25,18 @@ public class RecruitmentPositionQueryController {
 
     private final RecruitmentPositionQueryService recruitmentPositionQueryService;
 
-    @GetMapping("/v1/study/{studyId}/recruitment-position/{recruitmentPositionId}")
+    @GetMapping("/v1/recruitment-position/{recruitmentPositionId}/participation")
     @Operation(
             summary = "스터디 참여 조회",
             description = "스터디 참여 목록을 조회합니다. 스터디 작성자 전용입니다. "
     )
     public ApiResponse<PageResponse<GetStudyParticipationResponse>> getStudyParticipations(
-            @PathVariable("studyId") Long studyId,
             @PathVariable("recruitmentPositionId") Long recruitmentPositionId,
             Principal principal,
             GetStudyParticipationCondition condition
     ) {
         PageResponse<GetStudyParticipationResponse> pageResponse =
                 recruitmentPositionQueryService.getStudyParticipations(
-                        studyId,
                         recruitmentPositionId,
                         UUID.fromString(principal.getName()),
                         condition

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/dto/response/GetStudyParticipationDetailsResponse.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/dto/response/GetStudyParticipationDetailsResponse.java
@@ -37,7 +37,8 @@ public class GetStudyParticipationDetailsResponse {
     ) {
         return GetStudyParticipationDetailsResponse.builder()
                 .participationId(participation.getId())
-                .kakaoId(participation.getKakaoId())
+                .kakaoId(participation.getStatus() ==
+                        StudyParticipationStatus.ACCEPTED ? participation.getKakaoId() : null)
                 .status(participation.getStatus())
                 .coverLetter(participation.getCoverLetter())
                 .fileInfo(participation.getFileInfo())

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/dto/response/GetStudyParticipationDetailsResponse.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/dto/response/GetStudyParticipationDetailsResponse.java
@@ -33,12 +33,14 @@ public class GetStudyParticipationDetailsResponse {
     private String nickname;
 
     public static GetStudyParticipationDetailsResponse of(
-            StudyParticipation participation, List<StudyParticipationLink> participationLinks
+            StudyParticipation participation,
+            List<StudyParticipationLink> participationLinks,
+            boolean isStudyWriter
     ) {
         return GetStudyParticipationDetailsResponse.builder()
                 .participationId(participation.getId())
-                .kakaoId(participation.getStatus() ==
-                        StudyParticipationStatus.ACCEPTED ? participation.getKakaoId() : null)
+                .kakaoId(!isStudyWriter || (participation.getStatus() == StudyParticipationStatus.ACCEPTED)
+                        ? participation.getKakaoId() : null)
                 .status(participation.getStatus())
                 .coverLetter(participation.getCoverLetter())
                 .fileInfo(participation.getFileInfo())

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/entity/StudyParticipation.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/entity/StudyParticipation.java
@@ -1,5 +1,6 @@
 package com.jj.swm.domain.study.recruitmentposition.entity;
 
+import com.jj.swm.domain.study.core.entity.Study;
 import com.jj.swm.domain.study.recruitmentposition.dto.request.CreateStudyParticipationRequest;
 import com.jj.swm.domain.study.recruitmentposition.dto.request.UpdateStudyParticipationRequest;
 import com.jj.swm.domain.study.recruitmentposition.entity.embeddable.FileInfo;
@@ -45,6 +46,10 @@ public class StudyParticipation {
     private FileInfo fileInfo;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_recruitment_position_id", nullable = false)
     private StudyRecruitmentPosition recruitmentPosition;
 
@@ -54,7 +59,9 @@ public class StudyParticipation {
 
     public static StudyParticipation of(
             CreateStudyParticipationRequest request,
+            Study study,
             StudyRecruitmentPosition recruitmentPosition,
+
             User user
     ) {
         return StudyParticipation.builder()
@@ -62,6 +69,7 @@ public class StudyParticipation {
                 .kakaoId(request.getKakaoId())
                 .coverLetter(request.getCoverLetter())
                 .fileInfo(request.getFileInfo())
+                .study(study)
                 .recruitmentPosition(recruitmentPosition)
                 .user(user)
                 .build();

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/RecruitmentPositionRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/RecruitmentPositionRepository.java
@@ -24,4 +24,7 @@ public interface RecruitmentPositionRepository extends
     void deleteAllByStudyIds(List<Long> studyIds);
 
     int countByStudyId(Long studyId);
+
+    @Query("select rp from StudyRecruitmentPosition rp join fetch rp.study where rp.id = ?1")
+    Optional<StudyRecruitmentPosition> findByIdWithStudy(Long recruitmentPositionId);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationLinkRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationLinkRepository.java
@@ -22,4 +22,8 @@ public interface StudyParticipationLinkRepository extends
     void deleteAllByParticipationId(Long participationId);
 
     List<StudyParticipationLink> findAllByParticipationId(Long participationId);
+
+    @Modifying
+    @Query("delete from StudyParticipationLink pl where pl.participation.id in (?1)")
+    void deleteAllByParticipationIds(List<Long> participationIds);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
@@ -58,4 +58,10 @@ public interface StudyParticipationRepository extends
 
     @Query("select p.id from StudyParticipation p where p.study.id in (?1)")
     List<Long> findIdsByStudyIds(List<Long> studyIds);
+
+    @Query(
+            value = "select * from study_participation where study_id = ?1 and user_id = ?2 order by id desc limit 1",
+            nativeQuery = true
+    )
+    Optional<StudyParticipation> findByStudyIdAndUserId(Long studyId, UUID userId);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
@@ -34,4 +34,6 @@ public interface StudyParticipationRepository extends
     Optional<StudyParticipation> findByIdWithUserAndStudy(Long id);
 
     Optional<StudyParticipation> findByIdAndUserId(Long id, UUID userId);
+
+    boolean existsByStudyIdAndUserId(Long studyId, UUID userId);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
@@ -4,6 +4,7 @@ import com.jj.swm.domain.study.recruitmentposition.dto.AcceptedStudyParticipatio
 import com.jj.swm.domain.study.recruitmentposition.entity.StudyParticipation;
 import com.jj.swm.domain.study.recruitmentposition.repository.custom.CustomStudyParticipationRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -36,4 +37,25 @@ public interface StudyParticipationRepository extends
     Optional<StudyParticipation> findByIdAndUserId(Long id, UUID userId);
 
     boolean existsByStudyIdAndUserId(Long studyId, UUID userId);
+
+    @Modifying
+    @Query("update StudyParticipation p set p.deletedAt = CURRENT_TIMESTAMP where p.recruitmentPosition.id = ?1")
+    void deleteAllByRecruitmentPositionId(Long recruitmentPositionId);
+
+    @Modifying
+    @Query("update StudyParticipation p set p.deletedAt = CURRENT_TIMESTAMP where p.study.id = ?1")
+    void deleteAllByStudyId(Long studyId);
+
+    @Modifying
+    @Query("update StudyParticipation p set p.deletedAt = CURRENT_TIMESTAMP where p.study.id in (?1)")
+    void deleteAllByStudyIds(List<Long> studyIds);
+
+    @Query("select p.id from StudyParticipation p where p.recruitmentPosition.id = ?1")
+    List<Long> findIdsByRecruitmentPositionId(Long recruitmentPositionId);
+
+    @Query("select p.id from StudyParticipation p where p.study.id = ?1")
+    List<Long> findIdsByStudyId(Long studyId);
+
+    @Query("select p.id from StudyParticipation p where p.study.id in (?1)")
+    List<Long> findIdsByStudyIds(List<Long> studyIds);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
@@ -27,15 +27,11 @@ public interface StudyParticipationRepository extends
             List<Long> recruitmentPositionIds
     );
 
-    @Query("select p from StudyParticipation p join fetch p.recruitmentPosition rp join fetch rp.study where p.id = ?1")
-    Optional<StudyParticipation> findByIdWithRecruitmentAndStudy(Long id);
+    @Query("select p from StudyParticipation p join fetch p.study where p.id = ?1")
+    Optional<StudyParticipation> findByIdWithStudy(Long id);
 
-    @Query("""
-        select p
-        from StudyParticipation p join fetch p.user join fetch p.recruitmentPosition rp join fetch rp.study
-        where p.id = ?1
-        """)
-    Optional<StudyParticipation> findByIdWithUserAndRecruitmentAndStudy(Long id);
+    @Query("select p from StudyParticipation p join fetch p.user join fetch p.study where p.id = ?1")
+    Optional<StudyParticipation> findByIdWithUserAndStudy(Long id);
 
     Optional<StudyParticipation> findByIdAndUserId(Long id, UUID userId);
 }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/repository/StudyParticipationRepository.java
@@ -36,8 +36,6 @@ public interface StudyParticipationRepository extends
 
     Optional<StudyParticipation> findByIdAndUserId(Long id, UUID userId);
 
-    boolean existsByStudyIdAndUserId(Long studyId, UUID userId);
-
     @Modifying
     @Query("update StudyParticipation p set p.deletedAt = CURRENT_TIMESTAMP where p.recruitmentPosition.id = ?1")
     void deleteAllByRecruitmentPositionId(Long recruitmentPositionId);

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
@@ -88,6 +88,10 @@ public class RecruitmentPositionCommandService {
                 recruitmentPositionRepository.findByIdWithStudy(recruitmentPositionId)
                         .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "Recruitment Position not found"));
 
+        Study study = recruitmentPosition.getStudy();
+
+        validateAlreadyExists(userId, study);
+
         validateAcceptedCountNotEqualHeadcount(
                 recruitmentPosition,
                 participationRepository.countByRecruitmentPositionIdAndAcceptedStatus(recruitmentPositionId)
@@ -97,7 +101,7 @@ public class RecruitmentPositionCommandService {
 
         StudyParticipation participation = StudyParticipation.of(
                 request,
-                recruitmentPosition.getStudy(),
+                study,
                 recruitmentPosition,
                 user
         );
@@ -153,6 +157,12 @@ public class RecruitmentPositionCommandService {
 
         participationLinkRepository.deleteAllByParticipationId(participation.getId());
         participationRepository.delete(participation);
+    }
+
+    private void validateAlreadyExists(UUID userId, Study study) {
+        if (participationRepository.existsByStudyIdAndUserId(study.getId(), userId)) {
+            throw new GlobalException(ErrorCode.NOT_VALID, "Already Exists");
+        }
     }
 
     private StudyParticipation findParticipationByIdAndUserIdOrThrowAlsoValidateStatusNotAccepted(

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
@@ -1,5 +1,6 @@
 package com.jj.swm.domain.study.recruitmentposition.service;
 
+import com.google.common.collect.Lists;
 import com.jj.swm.domain.study.core.entity.Study;
 import com.jj.swm.domain.study.core.repository.StudyRepository;
 import com.jj.swm.domain.study.recruitmentposition.constants.StudyParticipationConstants;
@@ -18,6 +19,7 @@ import com.jj.swm.global.common.enums.ErrorCode;
 import com.jj.swm.global.exception.GlobalException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -32,6 +34,9 @@ import static com.jj.swm.global.common.util.ListCheckUtils.isListPresent;
 @Service
 @RequiredArgsConstructor
 public class RecruitmentPositionCommandService {
+
+    @Value("${spring.jpa.properties.hibernate.jdbc.batch_size}")
+    private int batchSize;
 
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
@@ -75,6 +80,10 @@ public class RecruitmentPositionCommandService {
     public void deleteRecruitmentPosition(Long recruitmentPositionId, UUID userId) {
         StudyRecruitmentPosition recruitmentPosition = findByIdAndUserIdOrThrow(recruitmentPositionId, userId);
 
+        List<Long> participationIds = participationRepository.findIdsByRecruitmentPositionId(recruitmentPositionId);
+        Lists.partition(participationIds, batchSize)
+                .forEach(participationLinkRepository::deleteAllByParticipationIds);
+        participationRepository.deleteAllByRecruitmentPositionId(recruitmentPositionId);
         recruitmentPositionRepository.delete(recruitmentPosition);
     }
 

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
@@ -84,8 +84,9 @@ public class RecruitmentPositionCommandService {
             Long recruitmentPositionId,
             UUID userId
     ) {
-        StudyRecruitmentPosition recruitmentPosition = recruitmentPositionRepository.findById(recruitmentPositionId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "Recruitment Position not found"));
+        StudyRecruitmentPosition recruitmentPosition =
+                recruitmentPositionRepository.findByIdWithStudy(recruitmentPositionId)
+                        .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "Recruitment Position not found"));
 
         validateAcceptedCountNotEqualHeadcount(
                 recruitmentPosition,
@@ -96,6 +97,7 @@ public class RecruitmentPositionCommandService {
 
         StudyParticipation participation = StudyParticipation.of(
                 request,
+                recruitmentPosition.getStudy(),
                 recruitmentPosition,
                 user
         );
@@ -114,7 +116,7 @@ public class RecruitmentPositionCommandService {
 
         validateNewStatusNotPending(newStatus);
 
-        StudyParticipation participation = participationRepository.findByIdWithRecruitmentAndStudy(participationId)
+        StudyParticipation participation = participationRepository.findByIdWithStudy(participationId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "study participation not found"));
 
         validateOldStatusMustPending(participation);
@@ -134,7 +136,7 @@ public class RecruitmentPositionCommandService {
             Long participationId,
             UUID userId
     ) {
-        StudyParticipation participation = findParticipationByIdAndUserIdOrThrowAndValidateStatusNotAccepted(
+        StudyParticipation participation = findParticipationByIdAndUserIdOrThrowAlsoValidateStatusNotAccepted(
                 participationId, userId
         );
 
@@ -145,7 +147,7 @@ public class RecruitmentPositionCommandService {
 
     @Transactional
     public void deleteStudyParticipation(Long participationId, UUID userId) {
-        StudyParticipation participation = findParticipationByIdAndUserIdOrThrowAndValidateStatusNotAccepted(
+        StudyParticipation participation = findParticipationByIdAndUserIdOrThrowAlsoValidateStatusNotAccepted(
                 participationId, userId
         );
 
@@ -153,7 +155,7 @@ public class RecruitmentPositionCommandService {
         participationRepository.delete(participation);
     }
 
-    private StudyParticipation findParticipationByIdAndUserIdOrThrowAndValidateStatusNotAccepted(
+    private StudyParticipation findParticipationByIdAndUserIdOrThrowAlsoValidateStatusNotAccepted(
             Long participationId, UUID userId
     ) {
         StudyParticipation participation = participationRepository.findByIdAndUserId(participationId, userId)
@@ -217,7 +219,7 @@ public class RecruitmentPositionCommandService {
     }
 
     private void validateStudyWriter(StudyParticipation participation, UUID userId) {
-        if (!participation.getRecruitmentPosition().getStudy().getUser().getId().equals(userId)) {
+        if (!participation.getStudy().getUser().getId().equals(userId)) {
             throw new GlobalException(ErrorCode.FORBIDDEN, "not study writer");
         }
     }

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
@@ -175,7 +175,8 @@ public class RecruitmentPositionCommandService {
         optionalParticipation.ifPresent(participation -> {
             if (participation.getDeletedAt() == null) {
                 throw new GlobalException(ErrorCode.NOT_VALID, "Already Exists");
-            } else if (LocalDateTime.now().isBefore(participation.getDeletedAt().plusDays(3))) {
+            } else if (participation.getStatus() == StudyParticipationStatus.REJECTED
+                    && LocalDateTime.now().isBefore(participation.getDeletedAt().plusDays(3))) {
                 throw new GlobalException(ErrorCode.NOT_VALID, "Three days have not passed yet.");
             }
         });

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandService.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -99,7 +100,7 @@ public class RecruitmentPositionCommandService {
 
         Study study = recruitmentPosition.getStudy();
 
-        validateAlreadyExists(userId, study);
+        validateAlreadyExistsAndBeforeThreeDays(study, userId);
 
         validateAcceptedCountNotEqualHeadcount(
                 recruitmentPosition,
@@ -168,10 +169,16 @@ public class RecruitmentPositionCommandService {
         participationRepository.delete(participation);
     }
 
-    private void validateAlreadyExists(UUID userId, Study study) {
-        if (participationRepository.existsByStudyIdAndUserId(study.getId(), userId)) {
-            throw new GlobalException(ErrorCode.NOT_VALID, "Already Exists");
-        }
+    private void validateAlreadyExistsAndBeforeThreeDays(Study study, UUID userId) {
+        Optional<StudyParticipation> optionalParticipation =
+                participationRepository.findByStudyIdAndUserId(study.getId(), userId);
+        optionalParticipation.ifPresent(participation -> {
+            if (participation.getDeletedAt() == null) {
+                throw new GlobalException(ErrorCode.NOT_VALID, "Already Exists");
+            } else if (LocalDateTime.now().isBefore(participation.getDeletedAt().plusDays(3))) {
+                throw new GlobalException(ErrorCode.NOT_VALID, "Three days have not passed yet.");
+            }
+        });
     }
 
     private StudyParticipation findParticipationByIdAndUserIdOrThrowAlsoValidateStatusNotAccepted(

--- a/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionQueryService.java
+++ b/src/main/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionQueryService.java
@@ -1,11 +1,12 @@
 package com.jj.swm.domain.study.recruitmentposition.service;
 
-import com.jj.swm.domain.study.core.repository.StudyRepository;
 import com.jj.swm.domain.study.recruitmentposition.dto.GetStudyParticipationCondition;
 import com.jj.swm.domain.study.recruitmentposition.dto.response.GetStudyParticipationDetailsResponse;
 import com.jj.swm.domain.study.recruitmentposition.dto.response.GetStudyParticipationResponse;
 import com.jj.swm.domain.study.recruitmentposition.entity.StudyParticipation;
 import com.jj.swm.domain.study.recruitmentposition.entity.StudyParticipationLink;
+import com.jj.swm.domain.study.recruitmentposition.entity.StudyRecruitmentPosition;
+import com.jj.swm.domain.study.recruitmentposition.repository.RecruitmentPositionRepository;
 import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationLinkRepository;
 import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationRepository;
 import com.jj.swm.global.common.constants.PageSize;
@@ -23,19 +24,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RecruitmentPositionQueryService {
 
-    private final StudyRepository studyRepository;
+    private final RecruitmentPositionRepository recruitmentPositionRepository;
     private final StudyParticipationRepository participationRepository;
     private final StudyParticipationLinkRepository participationLinkRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<GetStudyParticipationResponse> getStudyParticipations(
-            Long studyId,
             Long recruitmentPositionId,
             UUID userId,
             GetStudyParticipationCondition condition
     ) {
-        studyRepository.findByIdAndUserId(studyId, userId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "study not found"));
+        StudyRecruitmentPosition recruitmentPosition =
+                recruitmentPositionRepository.findByIdWithStudy(recruitmentPositionId)
+                        .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "recruitment position not found"));
+
+        validateStudyWriter(recruitmentPosition, userId);
 
         List<StudyParticipation> participations =
                 participationRepository.findPagedStudyParticipationByConditionWithUser(
@@ -65,17 +68,31 @@ public class RecruitmentPositionQueryService {
             Long participationId, UUID userId
     ) {
         StudyParticipation participation =
-                participationRepository.findByIdWithUserAndRecruitmentAndStudy(participationId)
+                participationRepository.findByIdWithUserAndStudy(participationId)
                         .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND, "study participation not found"));
 
-        if (!participation.getUser().getId().equals(userId) &&
-                !participation.getRecruitmentPosition().getStudy().getUser().getId().equals(userId)) {
+        boolean isStudyWriter;
+        if (participation.getUser().getId().equals(userId)) {
+            isStudyWriter = false;
+        } else if (participation.getStudy().getUser().getId().equals(userId)) {
+            isStudyWriter = true;
+        } else {
             throw new GlobalException(ErrorCode.FORBIDDEN, "No Authorization");
         }
 
         List<StudyParticipationLink> participationLinks =
                 participationLinkRepository.findAllByParticipationId(participationId);
 
-        return GetStudyParticipationDetailsResponse.of(participation, participationLinks);
+        return GetStudyParticipationDetailsResponse.of(
+                participation,
+                participationLinks,
+                isStudyWriter
+        );
+    }
+
+    private void validateStudyWriter(StudyRecruitmentPosition recruitmentPosition, UUID userId) {
+        if (!recruitmentPosition.getStudy().getUser().getId().equals(userId)) {
+            throw new GlobalException(ErrorCode.FORBIDDEN, "not study writer");
+        }
     }
 }

--- a/src/main/resources/db/migration/V20250331193712__alter_table_stury_participation_add_foreign_key.sql
+++ b/src/main/resources/db/migration/V20250331193712__alter_table_stury_participation_add_foreign_key.sql
@@ -1,0 +1,4 @@
+alter table study_participation add column study_id bigint not null;
+
+alter table study_participation
+add constraint study_participation_study_id_fkey foreign key (study_id) references study(id);

--- a/src/test/java/com/jj/swm/domain/study/core/service/StudyCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/study/core/service/StudyCommandServiceIntegrationTest.java
@@ -15,7 +15,11 @@ import com.jj.swm.domain.study.core.fixture.dto.request.DeleteStudiesRequestFixt
 import com.jj.swm.domain.study.core.fixture.dto.request.UpdateStudyRequestFixture;
 import com.jj.swm.domain.study.core.fixture.dto.request.UpdateStudyStatusRequestFixture;
 import com.jj.swm.domain.study.core.repository.*;
+import com.jj.swm.domain.study.recruitmentposition.fixture.dto.request.CreateStudyParticipationRequestFixture;
 import com.jj.swm.domain.study.recruitmentposition.repository.RecruitmentPositionRepository;
+import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationLinkRepository;
+import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationRepository;
+import com.jj.swm.domain.study.recruitmentposition.service.RecruitmentPositionCommandService;
 import com.jj.swm.domain.user.core.entity.User;
 import com.jj.swm.domain.user.core.fixture.UserFixture;
 import com.jj.swm.domain.user.core.repository.UserRepository;
@@ -47,6 +51,9 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
     @Autowired
     private StudyCommentCommandService commentCommandService;
 
+    @Autowired
+    private RecruitmentPositionCommandService recruitmentPositionCommandService;
+
     // repository
     @Autowired
     private UserRepository userRepository;
@@ -72,10 +79,16 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
     @Autowired
     private StudyStudyCommentRepository commentRepository;
 
+    @Autowired
+    private StudyParticipationRepository participationRepository;
+
+    @Autowired
+    private StudyParticipationLinkRepository participationLinkRepository;
+
     // entity
     private User user;
-
     private final Long studyId = 1L; // setUp 시 생성된 스터디 모집의 id값
+    private final Long recruitmentPositionId = 1L; // setUp 시 생성된 모집 포지션의 id 값
 
     private ExecutorService executorService;
     private CountDownLatch countDownLatch;
@@ -432,6 +445,12 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
                 user.getId()
         );
 
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.create(),
+                recruitmentPositionId,
+                user.getId()
+        );
+
         //when
         studyCommandService.deleteStudy(studyId, user.getId());
 
@@ -443,6 +462,8 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
         assertEquals(0, commentRepository.count());
         assertEquals(0, studyBookmarkRepository.count());
         assertEquals(0, studyRepository.count());
+        assertEquals(0, participationRepository.count());
+        assertEquals(0, participationLinkRepository.count());
     }
 
     @Test
@@ -451,6 +472,7 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
         //given
         studyCommandService.createStudy(CreateStudyRequestFixture.create(), user.getId());
         Long newStudyId = 2L;
+        Long newRecruitmentPositionId = 3L; // setUp에서 2개 생성했으므로 새로 생성된 모집 포지션 ID는 3부터 시작
 
         studyCommandService.createStudyLike(studyId, user.getId());
         studyCommandService.createStudyBookmark(studyId, user.getId());
@@ -485,6 +507,18 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
                 user.getId()
         );
 
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.create(),
+                recruitmentPositionId,
+                user.getId()
+        );
+
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.create(),
+                newRecruitmentPositionId,
+                user.getId()
+        );
+
         //when
         studyCommandService.deleteStudies(
                 DeleteStudiesRequestFixture.create(List.of(studyId, newStudyId)), user.getId()
@@ -498,6 +532,8 @@ class StudyCommandServiceIntegrationTest extends IntegrationContainerSupporter {
         assertEquals(0, commentRepository.count());
         assertEquals(0, studyBookmarkRepository.count());
         assertEquals(0, studyRepository.count());
+        assertEquals(0, participationRepository.count());
+        assertEquals(0, participationLinkRepository.count());
     }
 
     @Test

--- a/src/test/java/com/jj/swm/domain/study/recruitmentposition/fixture/entity/StudyParticipationFixture.java
+++ b/src/test/java/com/jj/swm/domain/study/recruitmentposition/fixture/entity/StudyParticipationFixture.java
@@ -1,0 +1,29 @@
+package com.jj.swm.domain.study.recruitmentposition.fixture.entity;
+
+import com.jj.swm.domain.study.core.entity.Study;
+import com.jj.swm.domain.study.recruitmentposition.entity.StudyParticipation;
+import com.jj.swm.domain.study.recruitmentposition.entity.StudyParticipationStatus;
+import com.jj.swm.domain.study.recruitmentposition.entity.StudyRecruitmentPosition;
+import com.jj.swm.domain.user.core.entity.User;
+
+import java.time.LocalDateTime;
+
+public class StudyParticipationFixture {
+
+    public static StudyParticipation createForDeletedAtAfterThreeDaysSuccess(
+            Study study,
+            StudyRecruitmentPosition recruitmentPosition,
+            User user
+    ) {
+        return StudyParticipation.builder()
+                .study(study)
+                .deletedAt(LocalDateTime.now().minusDays(3))
+                .coverLetter("test_cover_letter")
+                .kakaoId("test_kakaoId")
+                .status(StudyParticipationStatus.REJECTED)
+                .recruitmentPosition(recruitmentPosition)
+                .fileInfo(null)
+                .user(user)
+                .build();
+    }
+}

--- a/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
@@ -145,12 +145,6 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.create(),
                 recruitmentPositionId,
-                user1.getId()
-        );
-
-        recruitmentPositionCommandService.createStudyParticipation(
-                CreateStudyParticipationRequestFixture.create(),
-                recruitmentPositionId,
                 user2.getId()
         );
 

--- a/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.jj.swm.domain.study.recruitmentposition.service;
 
 import com.jj.swm.IntegrationContainerSupporter;
+import com.jj.swm.domain.study.core.entity.Study;
 import com.jj.swm.domain.study.core.fixture.dto.request.CreateStudyRequestFixture;
+import com.jj.swm.domain.study.core.repository.StudyRepository;
 import com.jj.swm.domain.study.core.service.StudyCommandService;
 import com.jj.swm.domain.study.recruitmentposition.dto.request.CreateStudyParticipationRequest;
 import com.jj.swm.domain.study.recruitmentposition.dto.request.UpdateStudyParticipationRequest;
@@ -15,6 +17,7 @@ import com.jj.swm.domain.study.recruitmentposition.fixture.dto.request.CreateStu
 import com.jj.swm.domain.study.recruitmentposition.fixture.dto.request.UpdateStudyParticipationRequestFixture;
 import com.jj.swm.domain.study.recruitmentposition.fixture.dto.request.UpdateStudyParticipationStatusRequestFixture;
 import com.jj.swm.domain.study.recruitmentposition.fixture.dto.request.UpsertRecruitmentPositionRequestFixture;
+import com.jj.swm.domain.study.recruitmentposition.fixture.entity.StudyParticipationFixture;
 import com.jj.swm.domain.study.recruitmentposition.repository.RecruitmentPositionRepository;
 import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationLinkRepository;
 import com.jj.swm.domain.study.recruitmentposition.repository.StudyParticipationRepository;
@@ -53,6 +56,9 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
 
     @Autowired
     private StudyParticipationLinkRepository participationLinkRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
 
     // entity
     private User user1;
@@ -208,7 +214,68 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
 
     @Test
     @DisplayName("이미 스터디 참여를 생성했으면 실패한다.")
-    void createStudyParticipation_WhenAlreadyExists_Success() {
+    void createStudyParticipation_WhenAlreadyExists_ThenFail() {
+        //when & then
+        assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),
+                recruitmentPositionId,
+                user1.getId()
+        ));
+    }
+
+    @Test
+    @DisplayName("거절 상태가 아닌 참여 신청은 지우고 3일 이내에 참여를 생성해도 성공한다.")
+    void createStudyParticipation_WhenDeletedNotRejectedParticipation_Success() {
+        //given
+        recruitmentPositionCommandService.deleteStudyParticipation(recruitmentPositionId, user1.getId());
+
+        //when & then
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),
+                recruitmentPositionId,
+                user1.getId()
+        );
+        Long newParticipationId = 2L;
+
+        Optional<StudyParticipation> optionalParticipation = participationRepository.findById(newParticipationId);
+        assertTrue(optionalParticipation.isPresent());
+    }
+
+    @Test
+    @DisplayName("거절 상태 참여 신청은 지우고 3일 이후에 참여를 생성하면 성공한다.")
+    void createStudyParticipation_WhenDeletedRejectedParticipationAfterThreeDays_Success() {
+        //given
+        Study study = studyRepository.findById(studyId).get();
+        StudyRecruitmentPosition recruitmentPosition = recruitmentPositionRepository.findById(recruitmentPositionId).get();
+        participationRepository.save(StudyParticipationFixture.createForDeletedAtAfterThreeDaysSuccess(
+                study,
+                recruitmentPosition,
+                user2
+        ));
+
+        //when & then
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),
+                recruitmentPositionId,
+                user2.getId()
+        );
+        Long newParticipationId = 3L; // 위에서 하나 들어갔으므로 id가 3일 차례
+
+        Optional<StudyParticipation> optionalParticipation = participationRepository.findById(newParticipationId);
+        assertTrue(optionalParticipation.isPresent());
+    }
+
+    @Test
+    @DisplayName("거절 상태의 참여 신청을 지우고 3일이 지나기 전에 참여를 생성하면 실패한다.")
+    void createStudyParticipation_WhenDeletedRejectedParticipationWithinThreeDays_ThenFail() {
+        //given
+        recruitmentPositionCommandService.updateStudyParticipationStatus(
+                UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.REJECTED),
+                participationId,
+                user1.getId()
+        );
+        recruitmentPositionCommandService.deleteStudyParticipation(recruitmentPositionId, user1.getId());
+
         //when & then
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),

--- a/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
+++ b/src/test/java/com/jj/swm/domain/study/recruitmentposition/service/RecruitmentPositionCommandServiceIntegrationTest.java
@@ -55,19 +55,21 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
     private StudyParticipationLinkRepository participationLinkRepository;
 
     // entity
-    private User user;
+    private User user1;
+    private User user2;
     private final Long studyId = 1L;
     private final Long participationId = 1L;
     private final Long recruitmentPositionId = 1L; // addStudy 할 시에 모집 포지션 2개 삽입
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(UserFixture.create());
-        studyCommandService.createStudy(CreateStudyRequestFixture.create(), user.getId());
+        user1 = userRepository.save(UserFixture.create());
+        user2 = userRepository.save(UserFixture.create());
+        studyCommandService.createStudy(CreateStudyRequestFixture.create(), user1.getId());
         recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.create(),
                 recruitmentPositionId,
-                user.getId()
+                user1.getId()
         );
     }
 
@@ -81,7 +83,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         Long newRecruitmentPositionId = recruitmentPositionCommandService.createRecruitmentPosition(
                 request,
                 studyId,
-                user.getId()
+                user1.getId()
         ).getRecruitmentPositionId();
 
         //then
@@ -103,7 +105,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
             recruitmentPositionCommandService.createRecruitmentPosition(
                     request,
                     studyId,
-                    user.getId()
+                    user1.getId()
             );
         }
 
@@ -111,7 +113,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.createRecruitmentPosition(
                 request,
                 studyId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -125,7 +127,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateRecruitmentPosition(
                 request,
                 recruitmentPositionId,
-                user.getId()
+                user1.getId()
         );
 
         //then
@@ -139,11 +141,26 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
     @Test
     @DisplayName("모집 포지션 삭제에 성공한다.")
     void deleteRecruitmentPosition_Success() {
+        //given
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.create(),
+                recruitmentPositionId,
+                user1.getId()
+        );
+
+        recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.create(),
+                recruitmentPositionId,
+                user2.getId()
+        );
+
         //when
-        recruitmentPositionCommandService.deleteRecruitmentPosition(recruitmentPositionId, user.getId());
+        recruitmentPositionCommandService.deleteRecruitmentPosition(recruitmentPositionId, user1.getId());
 
         //then
         assertEquals(1, recruitmentPositionRepository.count());
+        assertEquals(0, participationRepository.count());
+        assertEquals(0, participationLinkRepository.count());
     }
 
     @Test
@@ -152,7 +169,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         //when & then
         assertThrows(
                 GlobalException.class,
-                () -> recruitmentPositionCommandService.deleteRecruitmentPosition(123456789L, user.getId()));
+                () -> recruitmentPositionCommandService.deleteRecruitmentPosition(123456789L, user1.getId()));
     }
 
     @Test
@@ -165,7 +182,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.createStudyParticipation(
                 request,
                 recruitmentPositionId,
-                user.getId()
+                user2.getId()
         );
         Long newParticipationId = 2L;
 
@@ -186,13 +203,24 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),
                 recruitmentPositionId,
-                user.getId()
+                user2.getId()
         );
         Long newParticipationId = 2L;
 
         //then
         Optional<StudyParticipation> optionalParticipation = participationRepository.findById(newParticipationId);
         assertTrue(optionalParticipation.isPresent());
+    }
+
+    @Test
+    @DisplayName("이미 스터디 참여를 생성했으면 실패한다.")
+    void createStudyParticipation_WhenAlreadyExists_Success() {
+        //when & then
+        assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.createStudyParticipation(
+                CreateStudyParticipationRequestFixture.createForNoLinkAndFileUrlSuccess(),
+                recruitmentPositionId,
+                user1.getId()
+        ));
     }
 
     @Test
@@ -203,7 +231,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
                 recruitmentPositionCommandService.updateStudyParticipationStatus(
                         UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                         participationId,
-                        user.getId()
+                        user1.getId()
                 );
 
         //then
@@ -221,7 +249,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
                 recruitmentPositionCommandService.updateStudyParticipationStatus(
                         UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.REJECTED),
                         participationId,
-                        user.getId()
+                        user1.getId()
                 );
 
         //then
@@ -236,6 +264,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
     void updateStudyParticipationStatus_WhenAcceptedCountEqualsHeadcount_ThenFail() {
         //given
         for (int i = 1; i <= 3; i++) {
+            User user = userRepository.save(UserFixture.create());
             recruitmentPositionCommandService.createStudyParticipation(
                     CreateStudyParticipationRequestFixture.create(),
                     recruitmentPositionId,
@@ -247,7 +276,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
             recruitmentPositionCommandService.updateStudyParticipationStatus(
                     UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                     newParticipationId,
-                    user.getId()
+                    user1.getId()
             );
         }
 
@@ -255,7 +284,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -277,14 +306,14 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //when & then
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.REJECTED),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -295,7 +324,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.PENDING),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -304,6 +333,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
     void createStudyParticipation_WhenAcceptedCountEqualHeadcount_ThenFail() {
         //given
         for (int i = 0; i <= 2; i++) {
+            User user = userRepository.save(UserFixture.create());
             recruitmentPositionCommandService.createStudyParticipation(
                     CreateStudyParticipationRequestFixture.create(),
                     recruitmentPositionId,
@@ -315,7 +345,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
             recruitmentPositionCommandService.updateStudyParticipationStatus(
                     UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                     newParticipationId,
-                    user.getId()
+                    user1.getId()
             );
         }
 
@@ -323,7 +353,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.create(),
                 recruitmentPositionId,
-                user.getId()
+                user2.getId()
         ));
     }
 
@@ -334,7 +364,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.createStudyParticipation(
                 CreateStudyParticipationRequestFixture.create(),
                 recruitmentPositionId,
-                user.getId()
+                user2.getId()
         );
 
         Long newParticipationId = 2L;
@@ -342,20 +372,20 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 newParticipationId,
-                user.getId()
+                user1.getId()
         );
 
         //when & then
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateRecruitmentPosition(
                 UpsertRecruitmentPositionRequestFixture.updateForAcceptedCountLessThanHeadcountFail(),
                 recruitmentPositionId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -369,7 +399,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipation(
                 request,
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //then
@@ -396,7 +426,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.createForModifyLinkRequestNullSuccess(),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //then
@@ -416,7 +446,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.createForLinksToAddNullSuccess(),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //then
@@ -430,7 +460,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.createForLinkIdsToRemoveNullSuccess(),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //then
@@ -444,7 +474,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.createForExceedLinkLimitFail(),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -455,7 +485,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.createForUnderLinkLimitFail(),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -466,14 +496,14 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //when & then
         assertThrows(GlobalException.class, () -> recruitmentPositionCommandService.updateStudyParticipation(
                 UpdateStudyParticipationRequestFixture.create(),
                 participationId,
-                user.getId()
+                user1.getId()
         ));
     }
 
@@ -481,7 +511,7 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
     @DisplayName("스터디 참여 삭제에 성공한다.")
     void deleteStudyParticipation_Success() {
         //when
-        recruitmentPositionCommandService.deleteStudyParticipation(participationId, user.getId());
+        recruitmentPositionCommandService.deleteStudyParticipation(participationId, user1.getId());
 
         //then
         Optional<StudyParticipation> optionalParticipation = participationRepository.findById(participationId);
@@ -495,13 +525,13 @@ public class RecruitmentPositionCommandServiceIntegrationTest extends Integratio
         recruitmentPositionCommandService.updateStudyParticipationStatus(
                 UpdateStudyParticipationStatusRequestFixture.create(StudyParticipationStatus.ACCEPTED),
                 participationId,
-                user.getId()
+                user1.getId()
         );
 
         //when & then
         assertThrows(
                 GlobalException.class,
-                () -> recruitmentPositionCommandService.deleteStudyParticipation(participationId, user.getId())
+                () -> recruitmentPositionCommandService.deleteStudyParticipation(participationId, user1.getId())
         );
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 요약
<!-- 이 PR이 해결하는 문제나 추가하는 기능을 한 문장으로 설명해주세요 -->
스터디 참여 관련 API 수정 작업

## ✨ 수정사항
<!-- 주요 수정사항을 항목별로 설명해주세요 -->
- 참여 상태가 Accepted랑, 참여 신청자일 때만 kakaoId 보이도록 변경
- 스터디 참여 테이블에 스터디 의존성 추가
- 스터디, 유저 당 한 개의 참여 신청만 가능하도록 변경
- 모집 포지션, 스터디, 유저 삭제 시에 스터디 참여와 스터디 참여 링크 데이터도 삭제하도록 변경
- 거절 상태의 참여 신청을 지웠을 시, 참여 신청을 하려면 3일 뒤에 가능하도록 변경
- 위와 같은 사항에 따른 테스트 추가 및 변경

## 📝 PR 타입
- [ ] 🆕 신규 기능
- [x] 🐛 버그 수정
- [ ] 🔨 리팩토링
- [ ] 📚 문서 수정
- [ ] 🔧 설정 변경
- [x] 📝 테스트 작성

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
